### PR TITLE
Support for multiple input data types as the shard key

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,13 @@ Given a key and the number of shards, returns the shard for that key. This uses 
 const shardblade = require('shardblade');
 const TOTAL_SHARDS = 10;
 
-const shardbearers = [
-  {
-    name: 'Dalinar',
-    shardbladeName: 'Oathbringer',
-  },
-  {
-    name: 'Elhokar',
-    shardbladeName: 'Sunraiser',
-  },
-];
+const shardbearers = [{
+  name: 'Dalinar',
+  shardbladeName: 'Oathbringer'
+}, {
+  name: 'Elhokar',
+  shardbladeName: 'Sunraiser'
+}];
 
 shardbearers.forEach(shardbearer => {
   // let's decide which shard to go to based on the shardbearer's name

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Shardblade is a simple library for doing consistent sharding. It uses MurmurHash3 consistent hashing in order to distribute your keys evenly and consistently.
 
-This allows you to, given a string, produce the same shard every time. This should give you a reasonably even distribution of sharding for any inputs AND for any input the same shard should always be produced.
+This allows you to, given a value, produce the same shard every time. This should give you a reasonably even distribution of sharding for any inputs AND for any input the same shard should always be produced.
 
 To learn more about MurMurHash3, check out the wikipedia page: https://en.wikipedia.org/wiki/MurmurHash
 
@@ -20,13 +20,16 @@ Given a key and the number of shards, returns the shard for that key. This uses 
 const shardblade = require('shardblade');
 const TOTAL_SHARDS = 10;
 
-const shardbearers = [{
-  name: 'Dalinar',
-  shardbladeName: 'Oathbringer'
-}, {
-  name: 'Elhokar',
-  shardbladeName: 'Sunraiser'
-}];
+const shardbearers = [
+  {
+    name: 'Dalinar',
+    shardbladeName: 'Oathbringer',
+  },
+  {
+    name: 'Elhokar',
+    shardbladeName: 'Sunraiser',
+  },
+];
 
 shardbearers.forEach(shardbearer => {
   // let's decide which shard to go to based on the shardbearer's name

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ function slice(key, numShards) {
     keyClean = key.toString();
   }
 
-  const shardIndex = _hash(key) % numShards;
+  const shardIndex = _hash(keyClean) % numShards;
   return shardIndex;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,14 @@ function _hash(str) {
 
 // uses murmurhash3 for consistent hashing to distribute your key to a consistent shard
 function slice(key, numShards) {
+  // strigify key if possible to allow for multiple input data types
+  let keyClean = key;
+  if (typeof key === 'object') {
+    keyClean = key.toString();
+  } else if (key !== undefined) {
+    keyClean = key.toString();
+  }
+
   const shardIndex = _hash(key) % numShards;
   return shardIndex;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ function slice(key, numShards) {
   // strigify key if possible to allow for multiple input data types
   let keyClean = key;
   if (typeof key === 'object') {
-    keyClean = key.toString();
+    keyClean = JSON.stringify(key);
   } else if (key !== undefined) {
     keyClean = key.toString();
   }


### PR DESCRIPTION
Currently, the slice function always returns 1 for any non-string shard key. This change stringifies the shard key if possible before the hash function is performed, which requires a string.