### PR TITLE
Add type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Given a key and the number of shards, returns the shard for that key. This uses 
 #### example
 
 ```javascript
-const shardblade = require('shardblade');
+const shardblade = require('shardblade'); // OR: import shardblade from 'shardblade' (if using ES Modules)
 const TOTAL_SHARDS = 10;
 
 const shardbearers = [{

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "repository": "https://github.com/FabledWeb/shardblade",
   "main": "./src/",
+  "typings": "./types/index.d.ts",
   "readmeFilename": "README.md",
   "scripts": {
     "test": "echo \"no tests\" && exit 0"

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 /**
  * Generates a consistent shard for a given key.
- * @param key a value to generate the shard value from 
- * @param numShards the total number of shards
+ * @param key a value to generate the shard value from
+ * @param numShards the total number of shards. Must be a whole number
  */
  export function slice(key: any, numShards: number): number;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Generates a consistent shard for a given key.
+ * @param key a value to generate the shard value from 
+ * @param numShards the total number of shards
+ */
+ export function slice(key: any, numShards: number): number;


### PR DESCRIPTION
Adds type support for typescript usage.

Example ts import:
```
import { slice } from "shardblade";
slice(...)

OR

import shardblade from "shardblade";
shardblade.slice(...);
```
where `shardblade` in the second example could be anything since it's an anonymous export.